### PR TITLE
Overall changes to make it work with GCS with VFS library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.celarli.commons</groupId>
     <artifactId>vfs-gcs</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Google Cloud Storage Provider for the Apache Commons VFS library.</description>
@@ -130,11 +130,13 @@
             <artifactId>commons-collections4</artifactId>
             <version>4.0</version>
         </dependency>
+
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <version>1.6.0</version>
+            <version>1.38.0</version>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/main/java/com/celarli/commons/vfs/provider/google/GCSFileObject.java
+++ b/src/main/java/com/celarli/commons/vfs/provider/google/GCSFileObject.java
@@ -76,6 +76,11 @@ public class GCSFileObject extends AbstractFileObject {
 
         log.debug("Trying to get file type for:" + this.getName());
         URLFileName urlFileName = (URLFileName) this.getName();
+
+        if (urlFileName != null && urlFileName.getType() == FileType.FOLDER) {
+            return FileType.FOLDER;
+        }
+
         Bucket bucket = this.storage.get(urlFileName.getHostName());
         if (bucket == null || !bucket.exists()) {
             throw new IllegalArgumentException(format("Bucket %s does not exists", urlFileName.getHostName()));
@@ -93,16 +98,13 @@ public class GCSFileObject extends AbstractFileObject {
             return FileType.FILE;
         }
         else {
-            // GCS does not have folders.  Just files with path separators in
-            // their names.
+            // GCS does not have folders.  Just files with path separators in their names.
 
             // Here's the trick for folders.
             //
-            // Do a listing on that prefix.  If it returns anything, after not
-            // existing, then it's a folder.
+            // Do a listing on that prefix.  If it returns anything, after not existing, then it's a folder.
             String prefix = computePrefix(urlFileName);
-            log.debug(
-                    format("File does not :%s exists on bucket try to see if it's a directory", this.getName()));
+            log.debug(format("File does not :%s exists on bucket try to see if it's a directory", this.getName()));
             Page<Blob> blobs;
             if (prefix.equals("/")) {
                 // Special root path case. List the root blobs with no prefix
@@ -110,8 +112,7 @@ public class GCSFileObject extends AbstractFileObject {
             }
             else {
                 log.debug(format("listing directory :%s", prefix));
-                blobs = bucket.list(Storage.BlobListOption.currentDirectory(),
-                        Storage.BlobListOption.prefix(prefix));
+                blobs = bucket.list(Storage.BlobListOption.currentDirectory(), Storage.BlobListOption.prefix(prefix));
             }
             if (blobs.getValues().iterator().hasNext()) {
                 return FileType.FOLDER;

--- a/src/main/java/com/celarli/commons/vfs/provider/google/GCSFileObject.java
+++ b/src/main/java/com/celarli/commons/vfs/provider/google/GCSFileObject.java
@@ -213,7 +213,9 @@ public class GCSFileObject extends AbstractFileObject {
     protected void doAttach() throws Exception {
 
         URLFileName urlFileName = (URLFileName) this.getName();
+
         Bucket bucket = this.storage.get(urlFileName.getHostName());
+
         if (bucket == null || !bucket.exists()) {
             throw new IllegalArgumentException(format("Bucket %s does not exists", urlFileName.getHostName()));
         }

--- a/src/main/java/com/celarli/commons/vfs/provider/google/GCSFileProvider.java
+++ b/src/main/java/com/celarli/commons/vfs/provider/google/GCSFileProvider.java
@@ -1,14 +1,20 @@
 package com.celarli.commons.vfs.provider.google;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
-import org.apache.commons.vfs2.*;
+import org.apache.commons.vfs2.Capability;
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileSystem;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.provider.AbstractOriginatingFileProvider;
 import org.apache.commons.vfs2.provider.URLFileNameParser;
 
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+
 
 /**
  * A Commons VFS provider that allow connecting to the Google Cloud Storage
@@ -17,30 +23,55 @@ public class GCSFileProvider extends AbstractOriginatingFileProvider {
 
     static final Collection<Capability> capabilities =
             Collections.unmodifiableCollection(Arrays.asList(Capability.GET_TYPE,
-                                                             Capability.READ_CONTENT,
-                                                             Capability.APPEND_CONTENT,
-                                                             Capability.URI,
-                                                             Capability.ATTRIBUTES,
-                                                             Capability.RANDOM_ACCESS_READ,
-                                                             Capability.DIRECTORY_READ_CONTENT,
-                                                             Capability.LIST_CHILDREN,
-                                                             Capability.LAST_MODIFIED,
-                                                             Capability.GET_LAST_MODIFIED,
-                                                             Capability.CREATE,
-                                                             Capability.DELETE));
+                    Capability.READ_CONTENT,
+                    Capability.APPEND_CONTENT,
+                    Capability.URI,
+                    Capability.ATTRIBUTES,
+                    Capability.RANDOM_ACCESS_READ,
+                    Capability.DIRECTORY_READ_CONTENT,
+                    Capability.LIST_CHILDREN,
+                    Capability.LAST_MODIFIED,
+                    Capability.GET_LAST_MODIFIED,
+                    Capability.CREATE,
+                    Capability.DELETE)
+            );
 
 
-    @Override protected FileSystem doCreateFileSystem(FileName fileName, FileSystemOptions fileSystemOptions)
-            throws FileSystemException {
-        Storage storage = StorageOptions.getDefaultInstance().getService();
-        return new GCSFileSystem(fileName, fileSystemOptions, storage);
+    @Override
+    protected FileSystem doCreateFileSystem(FileName fileName, FileSystemOptions fileSystemOptions) {
+
+        try {
+
+            InputStream fis = GcsFileSystemConfigBuilder.getInstance().getKeyStream(fileSystemOptions);
+
+            Storage storage;
+            if (fis == null) {
+                storage = StorageOptions.getDefaultInstance().getService();
+            }
+            else {
+                GoogleCredentials credentials = GoogleCredentials.fromStream(fis);
+
+                storage = StorageOptions.newBuilder().setCredentials(credentials).build().getService();
+            }
+
+            return new GCSFileSystem(fileName, fileSystemOptions, storage);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
     }
 
-    @Override public Collection<Capability> getCapabilities() {
+
+    @Override
+    public Collection<Capability> getCapabilities() {
+
         return capabilities;
     }
 
+
     public GCSFileProvider() {
+
         setFileNameParser(new URLFileNameParser(80));
     }
 }

--- a/src/main/java/com/celarli/commons/vfs/provider/google/GCSFileProvider.java
+++ b/src/main/java/com/celarli/commons/vfs/provider/google/GCSFileProvider.java
@@ -51,7 +51,13 @@ public class GCSFileProvider extends AbstractOriginatingFileProvider {
             else {
                 GoogleCredentials credentials = GoogleCredentials.fromStream(fis);
 
-                storage = StorageOptions.newBuilder().setCredentials(credentials).build().getService();
+                String hostname = GcsFileSystemConfigBuilder.getInstance().getHostname(fileSystemOptions);
+                if (hostname != null) {
+                    storage = StorageOptions.newBuilder().setCredentials(credentials).setHost(hostname).build().getService();
+                }
+                else {
+                    storage = StorageOptions.newBuilder().setCredentials(credentials).build().getService();
+                }
             }
 
             return new GCSFileSystem(fileName, fileSystemOptions, storage);

--- a/src/main/java/com/celarli/commons/vfs/provider/google/GCSFileSystem.java
+++ b/src/main/java/com/celarli/commons/vfs/provider/google/GCSFileSystem.java
@@ -12,47 +12,56 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 
+
 /**
  * Implementation of a filesystem backed by a GCS bucket
  */
 public class GCSFileSystem extends AbstractFileSystem {
+
     /**
      * The GCS client
      */
     private final Storage storage;
 
+
     /**
      * Constructor
-     * @param rootName the file system root name
+     *
+     * @param rootName          the file system root name
      * @param fileSystemOptions the file system options
-     * @param storage the GCS client
+     * @param storage           the GCS client
      */
-    GCSFileSystem(@Nonnull FileName rootName,
-                  @Nullable FileSystemOptions fileSystemOptions,
-                  @Nonnull Storage storage) {
-        
+    GCSFileSystem(@Nonnull FileName rootName, @Nullable FileSystemOptions fileSystemOptions, @Nonnull Storage storage) {
+
         super(rootName, null, fileSystemOptions);
         this.storage = storage;
     }
 
+
     /**
      * Creates a file object so we can interact with
+     *
      * @param abstractFileName the file name of the object to interact with
      * @return the file object
      * @throws Exception if we can't create the file object
      */
     @Nonnull
-    @Override protected FileObject createFile(@Nonnull AbstractFileName abstractFileName) throws Exception {
-        return new GCSFileObject(abstractFileName,this,storage);
+    @Override
+    protected FileObject createFile(@Nonnull AbstractFileName abstractFileName) throws Exception {
+
+        return new GCSFileObject(abstractFileName, this, storage);
     }
+
 
     /**
      * Adds capabilities to this driver
+     *
      * @param caps the driver capabilities
      */
-    @Override protected void addCapabilities(@Nonnull Collection<Capability> caps) {
+    @Override
+    protected void addCapabilities(@Nonnull Collection<Capability> caps) {
+
         caps.addAll(GCSFileProvider.capabilities);
     }
-
 
 }

--- a/src/main/java/com/celarli/commons/vfs/provider/google/GcsFileSystemConfigBuilder.java
+++ b/src/main/java/com/celarli/commons/vfs/provider/google/GcsFileSystemConfigBuilder.java
@@ -1,0 +1,51 @@
+package com.celarli.commons.vfs.provider.google;
+
+import org.apache.commons.vfs2.FileSystem;
+import org.apache.commons.vfs2.FileSystemConfigBuilder;
+import org.apache.commons.vfs2.FileSystemOptions;
+
+import java.io.InputStream;
+
+
+public class GcsFileSystemConfigBuilder extends FileSystemConfigBuilder {
+
+    private static final GcsFileSystemConfigBuilder BUILDER = new GcsFileSystemConfigBuilder();
+
+
+    private GcsFileSystemConfigBuilder() {
+
+        super("gcs.");
+    }
+
+
+    public static GcsFileSystemConfigBuilder getInstance() {
+
+        return BUILDER;
+    }
+
+
+    @Override
+    protected Class<? extends FileSystem> getConfigClass() {
+
+        return GCSFileSystem.class;
+    }
+
+
+    /**
+     * Set the input stream for json key file to access GCS
+     */
+    public void setKeyStream(FileSystemOptions opts, InputStream fis) {
+
+        setParam(opts, "jsonKey", fis);
+    }
+
+
+    /**
+     * Get the input stream set by file system to access GCS
+     */
+    public InputStream getKeyStream(FileSystemOptions opts) {
+
+        return (InputStream) getParam(opts, "jsonKey");
+    }
+
+}

--- a/src/main/java/com/celarli/commons/vfs/provider/google/GcsFileSystemConfigBuilder.java
+++ b/src/main/java/com/celarli/commons/vfs/provider/google/GcsFileSystemConfigBuilder.java
@@ -32,20 +32,37 @@ public class GcsFileSystemConfigBuilder extends FileSystemConfigBuilder {
 
 
     /**
-     * Set the input stream for json key file to access GCS
+     * Set the input stream for key to access GCS
      */
     public void setKeyStream(FileSystemOptions opts, InputStream fis) {
 
-        setParam(opts, "jsonKey", fis);
+        setParam(opts, "key", fis);
     }
 
 
     /**
-     * Get the input stream set by file system to access GCS
+     * Get the input stream for key to access GCS
      */
     public InputStream getKeyStream(FileSystemOptions opts) {
 
-        return (InputStream) getParam(opts, "jsonKey");
+        return (InputStream) getParam(opts, "key");
     }
 
+
+    /**
+     * Set the hostname, will be used while constructing storage client for GCS
+     */
+    public void setHostname(FileSystemOptions opts, String hostname) {
+
+        setParam(opts, "hostname", hostname);
+    }
+
+
+    /**
+     * Get the hostname, will be used while constructing storage client for GCS
+     */
+    public String getHostname(FileSystemOptions opts) {
+
+        return (String) getParam(opts, "hostname");
+    }
 }

--- a/src/test/java/com/celarli/commons/vfs/provider/google/GCSFileOperationTest.java
+++ b/src/test/java/com/celarli/commons/vfs/provider/google/GCSFileOperationTest.java
@@ -1,0 +1,51 @@
+package com.celarli.commons.vfs.provider.google;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.Selectors;
+import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
+import org.junit.Test;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.util.UUID;
+
+
+public class GCSFileOperationTest {
+
+    //@Test
+    public void testCopy() throws Exception {
+
+        String fileName = ""+ UUID.randomUUID();
+
+        // Now let's create a temp file just for upload
+        File temp = File.createTempFile(fileName, ".tmp");
+
+        try (FileWriter fw = new FileWriter(temp)) {
+            BufferedWriter bw = new BufferedWriter(fw);
+            bw.append("testing...");
+            bw.flush();
+        }
+
+        DefaultFileSystemManager fileSystemManager = new DefaultFileSystemManager();
+        fileSystemManager.addProvider("gcs", new GCSFileProvider());
+        fileSystemManager.init();
+
+        // Create a URL for creating this remote file
+        String bucket = "npd-test";
+        String currUriStr = String.format("%s://%s/%s", "gcs", bucket, fileName);
+
+        // Resolve the imaginary file remotely. So we have a file object
+        FileObject gcsFile = fileSystemManager.resolveFile(currUriStr);
+
+        // Resolve the local file for upload
+        FileObject localFile = fileSystemManager.resolveFile(String.format("file://%s", temp.getAbsolutePath()));
+
+        // Use the API to copy from one local file to the remote file
+        gcsFile.copyFrom(localFile, Selectors.SELECT_SELF);
+
+        // Delete the temp we don't need anymore
+        temp.delete();
+        localFile.delete();
+    }
+}


### PR DESCRIPTION
Overall changes to make it work with GCS with VFS library:

- Upgraded version of google cloud storage library
- Updated minor version to pom 1.0.1 to ensure new fixes are available to only newer version
- Fixed various method to look for folders when path starts with "/", if path starts with "/" (**i.e /folder1/subfolder1**) then gcs bucket fails to get object
- Updated doGetType() method to return type as FOLDER with path ends with "/", this is to support exists() method call for virtual folders
- Override getChildren() method, VFS library expect exception when getChildren() calls made for file location (**i.e. folder1/abc.txt**)
- Added support to specify file system options (**required for credential and hostname**)